### PR TITLE
Merge sebres 19

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -18,10 +18,10 @@ addons:
       #- tcl8.6-dev
 
 before_script:
-  # ATM trusty-cosmic have too old tcl version (8.6.0), thus install newest 8.6.9 from disco ...
-  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu disco main universe"
+  # ATM trusty-cosmic have too old tcl version (8.6.0), thus install newest 8.6.9 from eoan ...
+  - sudo add-apt-repository -y "deb http://archive.ubuntu.com/ubuntu eoan main universe"
   - sudo apt-get update
-  - sudo apt-get install -t disco -y tcl8.6 tcl8.6-dev
+  - sudo apt-get install -t eoan -y tcl8.6 tcl8.6-dev
   # show version:
   - echo puts [info patchlevel] | tclsh
   - export BUILD_DIR=$(pwd)

--- a/generic/tclClock.c
+++ b/generic/tclClock.c
@@ -143,6 +143,9 @@ static struct tm *	ThreadSafeLocalTime(const time_t *);
 static size_t		TzsetIfNecessary(void);
 static void		ClockDeleteCmdProc(ClientData);
 
+static int		ClockSafeCatchCmd(
+			    ClientData clientData, Tcl_Interp *interp,
+			    int objc, Tcl_Obj *const objv[]);
 /*
  * Structure containing description of "native" clock commands to create.
  */
@@ -176,6 +179,7 @@ static const struct ClockCommand clockCommands[] = {
 		ClockGetjuliandayfromerayearmonthdayObjCmd,	NULL, NULL},
     {"GetJulianDayFromEraYearWeekDay",
 		ClockGetjuliandayfromerayearweekdayObjCmd,	NULL, NULL},
+    {"catch",		ClockSafeCatchCmd,	TclCompileBasicMin1ArgCmd, NULL},
     {NULL, NULL, NULL, NULL}
 };
 
@@ -1323,7 +1327,7 @@ ClockSetupTimeZone(
     /* setup now */
     callargs[0] = dataPtr->literals[LIT_SETUPTIMEZONE];
     if (Tcl_EvalObjv(interp, 2, callargs, 0) == TCL_OK) {
-    	/* save unnormalized last used */
+	/* save unnormalized last used */
 	Tcl_SetObjRef(dataPtr->lastSetupTimeZoneUnnorm, timezoneObj);
 	return callargs[1];
     }
@@ -4552,6 +4556,76 @@ ClockSecondsObjCmd(
     Tcl_GetTime(&now);
     Tcl_SetObjResult(interp, Tcl_NewWideIntObj((Tcl_WideInt) now.sec));
     return TCL_OK;
+}
+
+/*
+ *----------------------------------------------------------------------
+ *
+ * ClockSafeCatchCmd --
+ *
+ *	Same as "::catch" command but avoids overwriting of interp state.
+ *
+ *	See [554117edde] for more info (and proper solution).
+ *
+ *----------------------------------------------------------------------
+ */
+int
+ClockSafeCatchCmd(
+    ClientData clientData,
+    Tcl_Interp *interp,
+    int objc,
+    Tcl_Obj *const objv[])
+{
+    typedef struct InterpState {
+        int status;			/* return code status */
+        int flags;			/* Each remaining field saves the */
+        int returnLevel;		/* corresponding field of the Interp */
+        int returnCode;			/* struct. These fields taken together are */
+        Tcl_Obj *errorInfo;		/* the "state" of the interp. */
+        Tcl_Obj *errorCode;
+        Tcl_Obj *returnOpts;
+        Tcl_Obj *objResult;
+        Tcl_Obj *errorStack;
+        int resetErrorStack;
+    } InterpState;
+
+    Interp *iPtr = (Interp *)interp;
+    int ret, flags = 0;
+    InterpState *statePtr;
+
+    if (objc == 1) {
+	/* wrong # args : */
+	return Tcl_CatchObjCmd(NULL, interp, objc, objv);
+    }
+
+    statePtr = (InterpState *)Tcl_SaveInterpState(interp, 0);
+    if (!statePtr->errorInfo) {
+	/* todo: avoid traced get of errorInfo here */
+	Tcl_InitObjRef(statePtr->errorInfo,
+		Tcl_ObjGetVar2(interp, iPtr->eiVar, NULL, 0));
+	flags |= ERR_LEGACY_COPY;
+    }
+    if (!statePtr->errorCode) {
+	/* todo: avoid traced get of errorCode here */
+	Tcl_InitObjRef(statePtr->errorCode,
+		Tcl_ObjGetVar2(interp, iPtr->ecVar, NULL, 0));
+	flags |= ERR_LEGACY_COPY;
+    }
+
+    /* original catch */
+    ret = Tcl_CatchObjCmd(NULL, interp, objc, objv);
+	
+    if (ret == TCL_ERROR) {
+	Tcl_DiscardInterpState((Tcl_InterpState)statePtr);
+	return TCL_ERROR;
+    }
+    /* overwrite result in state with catch result */
+    Tcl_SetObjRef(statePtr->objResult, Tcl_GetObjResult(interp));
+    /* set result (together with restore state) to interpreter */
+    (void) Tcl_RestoreInterpState(interp, (Tcl_InterpState)statePtr);
+    /* todo: unless ERR_LEGACY_COPY not set in restore (branch [bug-554117edde] not merged yet) */
+    iPtr->flags |= (flags & ERR_LEGACY_COPY);
+    return ret;
 }
 
 /*

--- a/generic/tclClockModInt.c
+++ b/generic/tclClockModInt.c
@@ -52,6 +52,7 @@ int TclCompileClockReadingCmd(Tcl_Interp *interp, Tcl_Parse *parsePtr,
 Tcl_ObjCmdProc *_ClockClicksObjCmd;
 Tcl_ObjCmdProc *_ClockMillisecondsObjCmd;
 Tcl_ObjCmdProc *_ClockMicrosecondsObjCmd;
+Tcl_ObjCmdProc * _TclNRCatchObjCmd;
 
 int ClockClicksObjCmd(ClientData clientData, Tcl_Interp *interp,
    int objc, Tcl_Obj *const *objv)
@@ -67,6 +68,12 @@ int ClockMicrosecondsObjCmd(ClientData clientData, Tcl_Interp *interp,
    int objc, Tcl_Obj *const *objv)
 {
     return _ClockMicrosecondsObjCmd(clientData, interp, objc, objv);
+}
+
+int Tcl_CatchObjCmd(ClientData dummy, Tcl_Interp *interp,
+   int objc, Tcl_Obj *const objv[])
+{
+    return Tcl_NRCallObjProc(interp, _TclNRCatchObjCmd, dummy, objc, objv);
 }
 
 /* Currently no external declaration for tclStringHashKeyType */
@@ -213,6 +220,9 @@ void _InitModTclIntInternals(Tcl_Interp *interp) {
 	InterpCommand(interp, "::tcl::clock::milliseconds")->objProc;
     _ClockMicrosecondsObjCmd =
 	InterpCommand(interp, "::tcl::clock::microseconds")->objProc;
+
+    _TclNRCatchObjCmd =
+	InterpCommand(interp, "::catch")->nreProc;
 }
 
 /*

--- a/lib/clock.tcl
+++ b/lib/clock.tcl
@@ -664,6 +664,7 @@ proc ::tcl::clock::EnterLocale { locale } {
 #
 #----------------------------------------------------------------------
 proc ::tcl::clock::_hasRegistry {} {
+    set res 0
     if { $::tcl_platform(platform) eq {windows} } {
 	if { [catch { package require registry 1.1 }] } {
 	    # try to load registry directly from root (if uninstalled / development env):
@@ -674,12 +675,12 @@ proc ::tcl::clock::_hasRegistry {} {
 		] registry
 	    }}
 	}
+	if { [namespace which -command ::registry] ne "" } {
+	    set res 1
+	}
     }
-    if { $::tcl_platform(platform) ne {windows} || [namespace which -command ::registry] eq "" } {
-    	proc ::tcl::clock::_hasRegistry {} {return 0}
-    	return 0
-    }
-    return 1
+    proc ::tcl::clock::_hasRegistry {} [list return $res]
+    return $res
 }
 
 #----------------------------------------------------------------------


### PR DESCRIPTION
implements safe "catch" in clock NS - avoid overwrite of interp state by select and setup timezone (as well as in other "catched" blocks on lazy loading or initialization);

windows: load registry package on demand only (if possible, using same safe "catch" command).