### PR TITLE
Un-hardcode paths

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -132,6 +132,20 @@ TEA_ADD_SOURCES([generic/tclClock.c           \
 TEA_ADD_TCL_SOURCES([lib/clock.tcl])
 
 #--------------------------------------------------------------------
+# Add --with-tzpath flag to set zoneinfo directory
+#--------------------------------------------------------------------
+AC_MSG_CHECKING([where to find tzdata zoneinfo])
+AC_ARG_WITH(tzpath, [  --with-tzpath        directory containing zoneinfo], with_tzpath=${withval}, with_tzpath=no)
+if test x"${with_tzpath}" = x"no"; then
+    AC_MSG_RESULT([use default])
+    TZPATH="/usr/share/zoneinfo /usr/share/lib/zoneinfo /usr/lib/zoneinfo /usr/local/etc/zoneinfo"
+else
+    AC_MSG_RESULT([${with_tzpath}])
+    TZPATH=${with_tzpath}
+fi
+AC_SUBST(TZPATH)
+
+#--------------------------------------------------------------------
 # __CHANGE__
 # Choose which headers you need.  Extension authors should try very
 # hard to only rely on the Tcl public header files.  Internal headers
@@ -218,4 +232,4 @@ TEA_PROG_TCLSH
 # which require substituting th AC variables in.  Include these here.
 #--------------------------------------------------------------------
 
-AC_OUTPUT([Makefile pkgIndex.tcl])
+AC_OUTPUT([Makefile pkgIndex.tcl lib/clock.tcl])

--- a/generic/tclDate.h
+++ b/generic/tclDate.h
@@ -110,6 +110,7 @@ typedef enum ClockLiteral {
     LIT_BCE,		LIT_CE,
     LIT_DAYOFMONTH,	LIT_DAYOFWEEK,		LIT_DAYOFYEAR,
     LIT_ERA,		LIT_GMT,		LIT_GREGORIAN,
+    LIT_LOCALTIME,
     LIT_INTEGER_VALUE_TOO_LARGE,
     LIT_ISO8601WEEK,	LIT_ISO8601YEAR,
     LIT_JULIANDAY,	LIT_LOCALSECONDS,
@@ -132,6 +133,7 @@ typedef enum ClockLiteral {
     "BCE",		"CE", \
     "dayOfMonth",	"dayOfWeek",		"dayOfYear", \
     "era",		":GMT",			"gregorian", \
+    ":localtime", \
     "integer value too large to represent", \
     "iso8601Week",	"iso8601Year", \
     "julianDay",	"localSeconds", \

--- a/lib/clock.tcl.in
+++ b/lib/clock.tcl.in
@@ -233,12 +233,7 @@ proc ::tcl::clock::Initialize {} {
     # to reside on various operating systems
 
     variable ZoneinfoPaths {}
-    foreach path {
-	/usr/share/zoneinfo
-	/usr/share/lib/zoneinfo
-	/usr/lib/zoneinfo
-	/usr/local/etc/zoneinfo
-    } {
+    foreach path [list @TZPATH@] {
 	if { [file isdirectory $path] } {
 	    lappend ZoneinfoPaths $path
 	}


### PR DESCRIPTION
# Changes in this PR

These changes reduce `tclclockmod`'s dependence on hard-coded paths to ensure that it functions correctly and predictably in environments that don't have them (like Nix-built docker containers or the Nix build sandbox).

## Add a `--with-tzpath` configure flag
This allows `tclclockmod` to use an arbitrary zoneinfo path set at compile time instead of relying on a hard-coded list of paths to search. If left unspecified, `tclclockmod`'s current behavior is used.

## Fix unwanted stateful behavior when `/etc/localtime` does not exist
Conveniently, test `clock-38.1` caught this one in the Nix build sandbox. Essentially, `clock format` uses can give an incorrect result, but only when `/etc/localtime` is missing and you're running on a non-Windows platform:
```
set ::env(TZ) CET-1:00
set t0 [clock format 0 -timezone :localtime] 
# t0 correct: Thu Jan 01 01:00:00 +0100 1970

unset ::env(TZ)
set t1 [clock format 0] 
# t1 wrong: Thu Jan 01 01:00:00 +0000 1970

set ::env(TZ) +01:23
set t2 [clock format 0]
# t2 correct: Thu Jan 01 01:23:00 +01:23 1970

unset ::env(TZ)
set t3 [clock format 0] 
# t3 correct: Thu Jan 01 00:00:00 +0000 1970 
```
Not only is `t1` wrong, `clock format` is behaving inconsistently even given the same arguments with all the same environment variables set (`t3` is computed with the same arguments and env as `t1`, but is correct).

The problem is in `ClockParseFmtScanArgs`: when `lastBase` claims to be `:localtime`, we may re-use a cached value for `lastBase.date` that was actually computed when `TZ` was something different. This PR checks specifically for this case and prevents the re-use of a cached `lastBase.date` when the `TZ` has changed and `lastBase->timezoneObj` is `":localtime"`.
