### PR TITLE
Fix configure error introduced in #5

### DIFF
--- a/configure.ac
+++ b/configure.ac
@@ -129,7 +129,7 @@ TEA_ADD_SOURCES([generic/tclClock.c           \
 
 #TEA_ADD_STUB_SOURCES([])
 
-TEA_ADD_TCL_SOURCES([lib/clock.tcl])
+TEA_ADD_TCL_SOURCES([lib/clock.tcl.in])
 
 #--------------------------------------------------------------------
 # Add --with-tzpath flag to set zoneinfo directory


### PR DESCRIPTION
This corrects a git hygiene mistake in #5 (thanks for your patience). After the changes in #5, running configure would not succeed without this.